### PR TITLE
After CWD, request explicit PWD to get the new working directory

### DIFF
--- a/src/CoreFtp/FtpClient.cs
+++ b/src/CoreFtp/FtpClient.cs
@@ -107,7 +107,12 @@
             if ( response.FtpStatusCode != FtpStatusCode.FileActionOK )
                 throw new FtpException( response.ResponseMessage );
 
-            WorkingDirectory = response.ResponseMessage.Split( '"' )[ 1 ];
+            var pwdResponse = await SendCommandAsync( FtpCommand.PWD );
+
+            if ( pwdResponse.FtpStatusCode != FtpStatusCode.PathnameCreated )
+                throw new FtpException( response.ResponseMessage );
+
+            WorkingDirectory = pwdResponse.ResponseMessage.Split( '"' )[ 1 ];
         }
 
         /// <summary>


### PR DESCRIPTION
CoreFTP currently expects the server to send the new working directory
directly in the response to the CWD command. However, I don't think this
is standard/generally expected behavior (at least, the server with which
I am testing it returns just "250 CWD command successful.").

So, let's request the new working directory using an explicit request
for PWD.