### PR TITLE
Support NLST for directory listing retrieval

### DIFF
--- a/src/CoreFtp/FtpClient.cs
+++ b/src/CoreFtp/FtpClient.cs
@@ -388,40 +388,60 @@
             if ( dataSocket == null )
                 throw new FtpException( "Could not establish a data connection" );
 
-            var mlsdResult = await SendCommandAsync( FtpCommand.MLSD );
+            var usingMlsd = true;
+            var result = await SendCommandAsync( FtpCommand.MLSD );
 
-            if ( ( mlsdResult.FtpStatusCode != FtpStatusCode.DataAlreadyOpen ) && ( mlsdResult.FtpStatusCode != FtpStatusCode.OpeningData ) )
-                throw new FtpException( "Could not retrieve directory listing " + mlsdResult.ResponseMessage );
+            if (result.FtpStatusCode == FtpStatusCode.CommandSyntaxError || result.FtpStatusCode == FtpStatusCode.CommandNotImplemented )
+            {
+                usingMlsd = false;
+                result = await SendCommandAsync( FtpCommand.NLST );
+            }
+
+            if ( (result.FtpStatusCode != FtpStatusCode.DataAlreadyOpen ) && (result.FtpStatusCode != FtpStatusCode.OpeningData ) )
+                throw new FtpException( "Could not retrieve directory listing " + result.ResponseMessage );
 
             var maxTime = DateTime.Now.AddSeconds( configuration.TimeoutSeconds );
             bool hasTimedOut;
 
-            string csv = string.Empty;
+            var rawResult = new StringBuilder();
 
-            do
+                do
+                {
+                    var buffer = new byte[BUFFER_SIZE];
+
+                    int byteCount = dataSocket.Receive(buffer, buffer.Length, 0);
+                    if (byteCount == 0) break;
+
+                    rawResult.Append(Encoding.ASCII.GetString(buffer, 0, byteCount));
+
+                    hasTimedOut = (configuration.TimeoutSeconds == 0) || (DateTime.Now < maxTime);
+                } while (hasTimedOut);
+
+                dataSocket.Shutdown(SocketShutdown.Both);
+
+                await GetResponseAsync();
+
+            var lines = rawResult.Replace(CARRIAGE_RETURN, string.Empty).ToString().Split(LINEFEED);
+            if (usingMlsd)
             {
-                var buffer = new byte[BUFFER_SIZE];
+                var nodes = (from node in lines
+                             where node.Contains($"type={nodeTypeString}")
+                             select node.ToFtpNode())
+                    .ToList();
 
-                int byteCount = dataSocket.Receive( buffer, buffer.Length, 0 );
-                csv += Encoding.ASCII.GetString( buffer, 0, byteCount );
+                return nodes.AsReadOnly();
+            }
+            else
+            {
+                var nodes = (from name in lines
+                            select new FtpNodeInformation
+                            {
+                                Name = name,
+                            })
+                    .ToList();
 
-                if ( byteCount == 0 ) break;
-
-                hasTimedOut = ( configuration.TimeoutSeconds == 0 ) || ( DateTime.Now < maxTime );
-            } while ( hasTimedOut );
-
-            dataSocket.Shutdown( SocketShutdown.Both );
-
-            await GetResponseAsync();
-
-
-            var nodes = ( from node in csv.Replace( CARRIAGE_RETURN, string.Empty )
-                                          .Split( LINEFEED )
-                          where node.Contains( $"type={nodeTypeString}" )
-                          select node.ToFtpNode() )
-                .ToList();
-
-            return nodes.AsReadOnly();
+                return nodes.AsReadOnly();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This patch adds alternative directory listing retrieval using NLST to fix #2.

However, NLST is less capable than MLSD, so this does not really fit into the interface split between
`ListFilesAsync` and `ListDirectoriesAsync`, returning detailed `FtpNodeInformation`, etc. Also, a better implementation would be more general, allowing to use still other ways how to list files in FTP, and detecting the correct command once at the connection open, e.g. using the `FEAT` command.

So, this is not a perfect final solution, I guess, and it might be rejected and implemented in a better way. However, it is a small improvement over the current version which might be improved later.