### PR TITLE
UnixDirectoryParser is not reading the last modified from files

### DIFF
--- a/src/CoreFtp/Components/DirectoryListing/Parser/UnixDirectoryParser.cs
+++ b/src/CoreFtp/Components/DirectoryListing/Parser/UnixDirectoryParser.cs
@@ -40,7 +40,7 @@
             {
                 NodeType = DetermineNodeType( matches.Groups[ "permissions" ] ),
                 Name = DetermineName( matches.Groups[ "name" ] ),
-                DateModified = DetermineDateModified( matches.Groups[ "modify" ] ),
+                DateModified = DetermineDateModified( matches.Groups[ "date" ] ),
                 Size = DetermineSize( matches.Groups[ "size" ] )
             };
 


### PR DESCRIPTION
UnixDirectoryParser is not reading the last modified from files, this can be fixed by reading the field "date" from the regular expression groups.