### PR TITLE
Added support for passive (PASV) mode

### DIFF
--- a/src/CoreFtp/Infrastructure/Extensions/StringExtensions.cs
+++ b/src/CoreFtp/Infrastructure/Extensions/StringExtensions.cs
@@ -22,10 +22,27 @@
             return string.Format( "{0}/{1}", operand.TrimEnd( '/' ), rightHandSide.Trim( '/' ) );
         }
 
+        internal static int? ExtractPasvPortNumber(this string operand)
+        {
+            var regex = new Regex( @"([0-9]{1,3}[|,]){1,}[0-9]{1,3}", RegexOptions.Compiled );
+            var match = regex.Match( operand );
+
+            if (!match.Success)
+                return null;
+
+            var values = match.Groups[0].Value.Split("|,".ToCharArray()).Select(int.Parse).ToArray();
+
+            if (values.Length != 6)
+                return null;
+
+            // 5th and 6th values contain the port number
+            return values[4]*256 + values[5];
+        }
 
         internal static int? ExtractEpsvPortNumber( this string operand )
         {
-            var regex = new Regex( @"(?:\|)(?<PortNumber>\d+)(?:\|)", RegexOptions.Compiled );
+            // Added , as separator
+            var regex = new Regex( @"(?:[\|,])(?<PortNumber>\d+)(?:[\|,])", RegexOptions.Compiled );
 
             var match = regex.Match( operand );
 


### PR DESCRIPTION
Solved two issues:
- Support for commas (,) as a separator for connection parameters, besides |
- Support for plain passive mode (PASV) whenever extended passive (EPSV) is not supported