### PR TITLE
Another FTP server directory format and Dependency Injection support

### DIFF
--- a/src/CoreFtp/Components/DirectoryListing/Parser/ParserExtensions.cs
+++ b/src/CoreFtp/Components/DirectoryListing/Parser/ParserExtensions.cs
@@ -12,6 +12,7 @@
                 "yyyyMMddHHmmss",
                 "yyyyMMddHHmmss.fff",
                 "MMM dd  yyyy",
+                "MMM dd yyyy",
                 "MMM  d  yyyy",
                 "MMM dd HH:mm",
                 "MMM  d HH:mm",

--- a/src/CoreFtp/Components/DirectoryListing/Parser/UnixDirectoryParser.cs
+++ b/src/CoreFtp/Components/DirectoryListing/Parser/UnixDirectoryParser.cs
@@ -15,7 +15,7 @@
                                                       @"(?<user>.+)\s+" +
                                                       @"(?<group>.+)\s+" +
                                                       @"(?<size>\d+)\s+" +
-                                                      @"(?<date>\w+\s+\d+\s+\d+:\d+|\w+\s+\d+\s+\d+)\s" +
+                                                      @"(?<date>\w+\s+\d+\s+\d+:\d+|\w+\s+\d+\s+\d+)\s+" +
                                                       @"(?<name>.*)$", RegexOptions.Compiled );
         private ILogger logger;
 

--- a/src/CoreFtp/FtpClient.cs
+++ b/src/CoreFtp/FtpClient.cs
@@ -666,8 +666,8 @@
         {
             Logger?.LogDebug( "Disposing of FtpClient" );
             Task.WaitAny( LogOutAsync() );
-            ControlStream.Dispose();
-            dataSocketSemaphore.Dispose();
+            ControlStream?.Dispose();
+            dataSocketSemaphore?.Dispose();
         }
     }
 }

--- a/src/CoreFtp/FtpClient.cs
+++ b/src/CoreFtp/FtpClient.cs
@@ -16,16 +16,16 @@
     using Infrastructure.Stream;
     using Microsoft.Extensions.Logging;
 
-    public class FtpClient : IDisposable
+    public class FtpClient : IDisposable, IFtpClient
     {
         private IDirectoryProvider directoryProvider;
         private ILogger logger;
         private Stream dataStream;
         internal readonly SemaphoreSlim dataSocketSemaphore = new SemaphoreSlim( 1, 1 );
-        public FtpClientConfiguration Configuration { get; }
+        public FtpClientConfiguration Configuration { get; private set; }
 
         internal IEnumerable<string> Features { get; private set; }
-        internal FtpControlStream ControlStream { get; }
+        internal FtpControlStream ControlStream { get; private set; }
         public bool IsConnected => ControlStream != null && ControlStream.IsConnected;
         public bool IsEncrypted => ControlStream != null && ControlStream.IsEncrypted;
         public bool IsAuthenticated { get; private set; }
@@ -41,7 +41,16 @@
             }
         }
 
+        public FtpClient()
+        {
+        }
+
         public FtpClient( FtpClientConfiguration configuration )
+        {
+            Configure(configuration);
+        }
+
+        public void Configure(FtpClientConfiguration configuration)
         {
             Configuration = configuration;
 

--- a/src/CoreFtp/IFtpClient.cs
+++ b/src/CoreFtp/IFtpClient.cs
@@ -1,0 +1,62 @@
+﻿namespace CoreFtp
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Enum;
+    using Infrastructure;
+    using Microsoft.Extensions.Logging;
+
+    public interface IFtpClient : IDisposable
+    {
+        ILogger Logger { set; }
+
+        bool IsConnected { get;  }
+
+        bool IsEncrypted { get; }
+
+        bool IsAuthenticated { get; }
+
+        string WorkingDirectory { get; }
+
+        void Configure(FtpClientConfiguration configuration);
+
+        Task LoginAsync();
+
+        Task LogOutAsync();
+
+        Task ChangeWorkingDirectoryAsync(string directory);
+
+        Task CreateDirectoryAsync(string directory);
+
+        Task RenameAsync(string from, string to);
+
+        Task DeleteDirectoryAsync(string directory);
+
+        Task<FtpResponse> SetClientName(string clientName);
+
+        Task<Stream> OpenFileReadStreamAsync(string fileName);
+
+        Task<Stream> OpenFileWriteStreamAsync(string fileName);
+
+        Task CloseFileDataStreamAsync(CancellationToken ctsToken = default(CancellationToken));
+
+        Task<ReadOnlyCollection<FtpNodeInformation>> ListAllAsync();
+
+        Task<ReadOnlyCollection<FtpNodeInformation>> ListFilesAsync();
+
+        Task<ReadOnlyCollection<FtpNodeInformation>> ListDirectoriesAsync();
+
+        Task DeleteFileAsync(string fileName);
+
+        Task SetTransferMode(FtpTransferMode transferMode, char secondType = '\0');
+
+        Task<long> GetFileSizeAsync(string fileName);
+
+        Task<FtpResponse> SendCommandAsync(FtpCommandEnvelope envelope, CancellationToken token = default(CancellationToken));
+
+        Task<FtpResponse> SendCommandAsync(string command, CancellationToken token = default(CancellationToken));
+    }
+}

--- a/tests/CoreFtp.Tests.Integration/FtpClientTests/Directories/When_Encountering_Differing_Directory_Formats.cs
+++ b/tests/CoreFtp.Tests.Integration/FtpClientTests/Directories/When_Encountering_Differing_Directory_Formats.cs
@@ -23,6 +23,7 @@
         [InlineData("-r-xr-xr-x   1 owner    group           14271 May  3  2:24 02001318~01488A2402001318.UHH", FtpNodeType.File, 14271, "-05-03T02:24", "02001318~01488A2402001318.UHH")]
         [InlineData("dr-xr-xr-x   1 owner    group               0 Oct 29  2013 Eycon", FtpNodeType.Directory, 0, "2013-10-29", "Eycon")]
         [InlineData("dr-xr-xr-x   1 owner    group               0 Jun  4  9:21 EYCON_40", FtpNodeType.Directory, 0, "-06-04T09:21", "EYCON_40")]
+        // Baby FTP (http://www.pablosoftwaresolutions.com/html/baby_ftp_server.html)
         [InlineData("-rwx------ 1 user group         400366 Jan 04 2011  DoncastersNo-417~816~20110103_00F1ED300000087D.uhh", FtpNodeType.File, 400366, "2011-01-04T00:00", "DoncastersNo-417~816~20110103_00F1ED300000087D.uhh")]
         public void Should_Accept(string listing, FtpNodeType nodeType, int size, string when, string filename)
         {

--- a/tests/CoreFtp.Tests.Integration/FtpClientTests/Directories/When_Encountering_Differing_Directory_Formats.cs
+++ b/tests/CoreFtp.Tests.Integration/FtpClientTests/Directories/When_Encountering_Differing_Directory_Formats.cs
@@ -23,6 +23,7 @@
         [InlineData("-r-xr-xr-x   1 owner    group           14271 May  3  2:24 02001318~01488A2402001318.UHH", FtpNodeType.File, 14271, "-05-03T02:24", "02001318~01488A2402001318.UHH")]
         [InlineData("dr-xr-xr-x   1 owner    group               0 Oct 29  2013 Eycon", FtpNodeType.Directory, 0, "2013-10-29", "Eycon")]
         [InlineData("dr-xr-xr-x   1 owner    group               0 Jun  4  9:21 EYCON_40", FtpNodeType.Directory, 0, "-06-04T09:21", "EYCON_40")]
+        [InlineData("-rwx------ 1 user group         400366 Jan 04 2011  DoncastersNo-417~816~20110103_00F1ED300000087D.uhh", FtpNodeType.File, 400366, "2011-01-04T00:00", "DoncastersNo-417~816~20110103_00F1ED300000087D.uhh")]
         public void Should_Accept(string listing, FtpNodeType nodeType, int size, string when, string filename)
         {
             if (when[0] == '-')


### PR DESCRIPTION
Babyftp support : The babyftp server has yet another variation on the directory listing format. There is an extra space before the filename and a missing space in the date section.

Support Dependency Injection Frameworks: Create an interface definition IFtpClient for FtpClient and derive FtpClient from it. Add a parameterless constructor and a Configure() method so that a dependency injection framework can make an IFtpClient and the consumer of that can configure the injected class. The original constructor is still available for use in non-DI environments.

Prevent null references in when Dispose is called: If an FtpClient is created, but not used, when Dispose is called don't Dispose of non-existent objects.