### PR TITLE
Correct log call

### DIFF
--- a/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
+++ b/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
@@ -46,7 +46,7 @@ namespace CoreFtp.Infrastructure.Stream
             }
             catch ( Exception e )
             {
-                Logger?.LogWarning( e, "Closing the data stream took longer than expected" );
+                Logger?.LogWarning( 0, e, "Closing the data stream took longer than expected" );
             }
             finally
             {

--- a/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
+++ b/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
@@ -46,7 +46,7 @@ namespace CoreFtp.Infrastructure.Stream
             }
             catch ( Exception e )
             {
-                Logger?.LogWarning( "Closing the data stream took longer than expected", e );
+                Logger?.LogWarning( e, "Closing the data stream took longer than expected" );
             }
             finally
             {


### PR DESCRIPTION
The current call is resolving to this overload:
https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L304

Whereas clearly the overloaded you intended is this one:
https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L287