### PR TITLE
Allow configuration of the disconnect timeout

### DIFF
--- a/src/CoreFtp/FtpClientConfiguration.cs
+++ b/src/CoreFtp/FtpClientConfiguration.cs
@@ -8,6 +8,7 @@
     public class FtpClientConfiguration
     {
         public int TimeoutSeconds { get; set; } = 120;
+        public int? DisconnectTimeoutMilliseconds { get; set; } = 100;
         public int Port { get; set; } = Constants.FtpPort;
         public string Host { get; set; }
         public IpVersion IpVersion { get; set; } = IpVersion.IpV4;

--- a/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
+++ b/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
@@ -41,7 +41,10 @@ namespace CoreFtp.Infrastructure.Stream
             {
                 encapsulatedStream.Dispose();
 
-                client.ControlStream.SetTimeouts( 100 );
+                if (client.Configuration.DisconnectTimeoutMilliseconds.HasValue)
+                {
+                    client.ControlStream.SetTimeouts( client.Configuration.DisconnectTimeoutMilliseconds.Value );
+                }
                 client.CloseFileDataStreamAsync().Wait();
             }
             catch ( Exception e )

--- a/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
+++ b/src/CoreFtp/Infrastructure/Stream/FtpDataStream.cs
@@ -41,7 +41,7 @@ namespace CoreFtp.Infrastructure.Stream
             {
                 encapsulatedStream.Dispose();
 
-                if (client.Configuration.DisconnectTimeoutMilliseconds.HasValue)
+                if ( client.Configuration.DisconnectTimeoutMilliseconds.HasValue )
                 {
                     client.ControlStream.SetTimeouts( client.Configuration.DisconnectTimeoutMilliseconds.Value );
                 }


### PR DESCRIPTION
Allow configuration of the timeout that is set on disposal of the `FtpDataStream`.

This fixes a real-world issue for us where writes to a third-party FTP server were not being persisted reliably because the disconnect cannot complete in 100ms and therefore is unable to complete cleanly.

Note that this does not change any behaviour by default, it merely allows us to configure the client to increase or remove the timeout in question.